### PR TITLE
fixed missing dependencies and make numpy 2 compatible

### DIFF
--- a/cheminfo/molecule/elements.py
+++ b/cheminfo/molecule/elements.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 ##############################################################################
@@ -156,7 +155,9 @@ _strings = """  0 0.00 0.00 0.00 0.00  0          0 0.00       0          0 0.07
 117 0.00 1.60 1.60 2.00  6        294 0.00       0          0 0.99 0.00 0.07
 118 0.00 1.60 1.60 2.00  6        294 0.00       0          0 0.99 0.00 0.06"""
 
-_dt = np.array( [ _si.split() for _si in _strings.split('\n') ] ).astype(np.float)
+# _dt = np.array( [ _si.split() for _si in _strings.split('\n') ] ).astype(np.float)
+# update due to np >=1.20 does not support float conversion
+_dt = np.array([_si.split() for _si in _strings.split("\n")]).astype(float)
 
 class Elements(object):
 
@@ -196,4 +197,3 @@ class Elements(object):
             self.rvdws = rvdws[zs]
             self.maxnbs = maxnbs[zs].astype(np.int)
             self.vsr = vsr[zs].astype(np.int)
-

--- a/cheminfo/oechem/amon.py
+++ b/cheminfo/oechem/amon.py
@@ -19,7 +19,7 @@ import scipy.spatial.distance as ssd
 import multiprocessing
 import aqml.cheminfo.core as cic
 import aqml.cheminfo.math as cim
-import cml.sd as dd
+#import cml.sd as dd # is no longer available
 import itertools as itl
 import tempfile as tpf
 import aqml.cheminfo.graph as cg

--- a/cheminfo/oechem/amon_mpi.py
+++ b/cheminfo/oechem/amon_mpi.py
@@ -19,7 +19,7 @@ import scipy.spatial.distance as ssd
 import multiprocessing as mt
 import aqml.cheminfo.core as cic
 import aqml.cheminfo.math as cim
-import cml.sd as dd
+#import cml.sd as dd
 import itertools as itl
 import tempfile as tpf
 import aqml.cheminfo.graph as cg


### PR DESCRIPTION
Hey bing tried to run it with python 3.12 meaning numpy 2 which broke the code. just in case this seems to fix it.
there is also one package cml which does not seem to be availie so i removed it - hoping this does not break the code 

```
 pip install cml                                                                                                      1 ✘   8s         py312     09:34:44 
Collecting cml
  Downloading cml-0.0.1.tar.gz (770 bytes)
  Preparing metadata (setup.py) ... done
Collecting cloud-ml-sdk>=0.2.12 (from cml)
  Downloading cloud_ml_sdk-0.3.71.tar.gz (61 kB)
  Preparing metadata (setup.py) ... done
Collecting requests>=2.6.0 (from cloud-ml-sdk>=0.2.12->cml)
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting pyOpenSSL>=16.1.0 (from cloud-ml-sdk>=0.2.12->cml)
  Downloading pyOpenSSL-24.3.0-py3-none-any.whl.metadata (15 kB)
Collecting argcomplete>=1.4.1 (from cloud-ml-sdk>=0.2.12->cml)
  Downloading argcomplete-3.5.2-py3-none-any.whl.metadata (16 kB)
Collecting grpcio>=1.2.0 (from cloud-ml-sdk>=0.2.12->cml)
  Downloading grpcio-1.68.1-cp312-cp312-macosx_10_9_universal2.whl.metadata (3.9 kB)
INFO: pip is looking at multiple versions of cloud-ml-sdk to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement cloud-ml-common>=0.2.2 (from cloud-ml-sdk) (from versions: 0.0.2)
ERROR: No matching distribution found for cloud-ml-common>=0.2.2
```